### PR TITLE
Fix missing self in bot sendmail

### DIFF
--- a/ticgithub/bot.py
+++ b/ticgithub/bot.py
@@ -17,7 +17,7 @@ class SMTP:
 
     def sendmail(self, email, recipients):
         with smtplib.SMTP_SSL(self.host, self.port) as smtp:
-            smtp.login(user, os.environ.get(self.secret))
+            smtp.login(self.user, os.environ.get(self.secret))
             smtp.sendmail(self.user, recipients, email.as_string())
 
     def __repr__(self):


### PR DESCRIPTION
Apparently I completely missed this -- only happened when I finally got an email that needed to post something in response.