### PR TITLE
Reminder tasks: Force `now` to be timezone-aware

### DIFF
--- a/ticgithub/tasks/reminder_task.py
+++ b/ticgithub/tasks/reminder_task.py
@@ -1,5 +1,5 @@
 import string
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import yaml
 
@@ -85,6 +85,9 @@ class ReminderTask(Task):
             return issue.date_created
 
     def _run(self, config, dry):
-        now = datetime.now()
+        # force now to be tz-unaware, but in UTC (appears to be what
+        # PyGithub returns)
+        now = datetime.now(tz=timezone.utc)
+        now = now.replace(tzinfo=None)
         for issue in self.get_relevant_issues():
             self._single_issue_check(issue, config, now, dry)

--- a/ticgithub/tasks/reminder_task.py
+++ b/ticgithub/tasks/reminder_task.py
@@ -92,6 +92,5 @@ class ReminderTask(Task):
         # force now to be tz-unaware, but in UTC (appears to be what
         # PyGithub returns)
         now = datetime.now(tz=timezone.utc)
-        now = now.replace(tzinfo=None)
         for issue in self.get_relevant_issues():
             self._single_issue_check(issue, config, now, dry)

--- a/ticgithub/tasks/reminder_task.py
+++ b/ticgithub/tasks/reminder_task.py
@@ -55,6 +55,10 @@ class ReminderTask(Task):
         snooze_time = self._get_snooze_time(issue, config)
 
         trigger_time = max([delay_time, snooze_time])
+        _logger.info(f"{delay_time=}")
+        _logger.info(f"{snooze_time=}")
+        _logger.info(f"{trigger_time=}")
+        _logger.info(f"{now=}")
         if now > trigger_time:
             _logger.info(f"CREATING COMMENT FOR ISSUE {issue.number}")
             comment = self.craft_reminder_comment(

--- a/ticgithub/tasks/reminder_task.py
+++ b/ticgithub/tasks/reminder_task.py
@@ -55,10 +55,10 @@ class ReminderTask(Task):
         snooze_time = self._get_snooze_time(issue, config)
 
         trigger_time = max([delay_time, snooze_time])
-        _logger.info(f"{delay_time=}")
-        _logger.info(f"{snooze_time=}")
-        _logger.info(f"{trigger_time=}")
-        _logger.info(f"{now=}")
+        _logger.debug(f"{delay_time=}")
+        _logger.debug(f"{snooze_time=}")
+        _logger.debug(f"{trigger_time=}")
+        _logger.debug(f"{now=}")
         if now > trigger_time:
             _logger.info(f"CREATING COMMENT FOR ISSUE {issue.number}")
             comment = self.craft_reminder_comment(


### PR DESCRIPTION
My best guess is that somehow PyGithub started assigning time zones to issue dates (apparently using `tzlocal()`?) This was causing problems.

Easiest way to solve the problem is to force a timezone on `datetime.now()`.